### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           # NB: this will break historic CI jobs (if breaking program changes happen)
           # better to ensure latest version works
-          SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
+          SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
           echo "downloading libdrift: $SO_URL"
           curl -L -o libdrift_ffi_sys.so "$SO_URL"
           sudo cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 [[package]]
 name = "drift-idl-gen"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.1"
-source = "git+https://github.com/drift-labs/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.16"
-source = "git+https://github.com/drift-labs/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=0618036#0618036d37d70d4a1ad0694eac75c5ae2036f937"
 dependencies = [
  "abi_stable",
  "ahash 0.8.12",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 actix-web = "*"
 argh = "*"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "0618036", features = ["titan"] }
+drift-rs = { git = "https://github.com/velocity-exchange/drift-rs", rev = "0618036", features = ["titan"] }
 base64 = "0.22.1"
 env_logger = "*"
 faster-hex = "0.10.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.85 AS builder
 RUN apt-get update && apt-get install -y libgcc1 jq
 WORKDIR /build
 RUN rustup component add rustfmt
-RUN SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url') &&\
+RUN SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url') &&\
   curl -L -o libdrift_ffi_sys.so "$SO_URL" &&\
   cp libdrift_ffi_sys.so /usr/local/lib
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run \
   -e DRIFT_GATEWAY_KEY=<BASE58_SEED> \
   -p 8080:8080 \
   --platform linux/x86_64 \
-  ghcr.io/drift-labs/gateway https://rpc-provider.example.com --host 0.0.0.0 \
+  ghcr.io/velocity-exchange/gateway https://rpc-provider.example.com --host 0.0.0.0 \
   --markets wbtc,drift
   --extra-rpcs https://api.mainnet-beta.solana.com
 ```
@@ -247,7 +247,7 @@ $ curl 'localhost:8080/v2/orders?ttl=2' -X POST \
 
 ## API Examples
 
-Please refer to https://drift-labs.github.io/v2-teacher/ for further examples and reference documentation on various types, fields, and operations available on drift.
+Please refer to https://velocity-exchange.github.io/v2-teacher/ for further examples and reference documentation on various types, fields, and operations available on drift.
 
 ### HTTP API
 
@@ -379,7 +379,7 @@ To query or stream orderbooks via WebSocket, public DLOB servers are available a
 - devnet: `wss://master.dlob.drift.trade/ws`
 - mainnet: `wss://dlob.drift.trade/ws`
 
-see https://github.com/drift-labs/dlob-server/blob/master/example/wsClient.ts for usage example
+see https://github.com/velocity-exchange/dlob-server/blob/master/example/wsClient.ts for usage example
 
 ### Get Orders
 
@@ -567,7 +567,7 @@ A response for a transaction that was confirmed onchain but failed execution e.g
   "success": false
 }
 ```
-full list of error codes [here](https://drift-labs.github.io/v2-teacher/#errors)
+full list of error codes [here](https://velocity-exchange.github.io/v2-teacher/#errors)
 
 ### Get SOL balance
 Return the on-chain SOL balance of the transaction signer (`DRIFT_GATEWAY_KEY`)
@@ -1041,7 +1041,7 @@ error responses have the following JSON structure:
 ```
 
 Some endpoints send transactions to the drift program and can return program error codes.
-The full list of drift program error codes is available in the [API docs](https://drift-labs.github.io/v2-teacher/#errors)
+The full list of drift program error codes is available in the [API docs](https://velocity-exchange.github.io/v2-teacher/#errors)
 
 ### FAQ
 


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` (Cargo.toml dep, Cargo.lock sources, README example, CI workflow)
- `api.github.com/repos/drift-labs/` → `api.github.com/repos/velocity-exchange/` (Dockerfile + CI: drift-ffi-sys release download)
- `ghcr.io/drift-labs/` → `ghcr.io/velocity-exchange/` (README Docker run example)
- `drift-labs.github.io` → `velocity-exchange.github.io` (README API docs links — v2-teacher, errors page)

**Total substitutions: 12 across 5 files.**

Files changed:
- `.github/workflows/build.yml` — drift-ffi-sys release download URL (1)
- `Cargo.toml` — drift-rs git dependency URL (1)
- `Cargo.lock` — drift-rs source URLs (×3) + jupiter-swap-api-client source URL (×1) (4)
- `Dockerfile` — drift-ffi-sys release download URL (1)
- `README.md` — ghcr.io image reference (1), github.io docs links (3), dlob-server example link (1) (5 substitutions)

## Skipped (upstream-Drift historical refs)

None — all occurrences in this repo are operational references (dependency URLs, release asset downloads, container image paths, doc-site links for this gateway's own usage) rather than historical fork-origin statements.

## Build note

`drift-rs` and `jupiter-swap-api-client` (a transitive dep of `drift-rs`) are sourced from GitHub git URLs. After the org rename, builds will fail until those repos exist under `velocity-exchange`. The Cargo.lock has been updated to reflect the new source URLs; `cargo update` may be needed once the repos are migrated.